### PR TITLE
Update README.md for `compact_str v0.8.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Name                                                  | Size     | Heap  | Inlin
 ------------------------------------------------------|----------|-------|----------|----------------|---------|--------|-----
 `String`                                              | 24 bytes | **Y** | \-       | N              | **Y**   | \-     | Universal
 `Cow<'static, str>`                                   | 24 bytes | **Y** | \-       | **Y**          | N       | \-     |
-[`arcstr`](https://crates.io/crates/arcstr)           | 8 bytes  | ?     | ?        | ?              | ?       | ?  | ?
-[`compact_str`](https://crates.io/crates/compact_str) | 24 bytes | **Y** | 24 bytes | N              | **Y**   | **Y** (miri, proptest, fuzz)  | Space optimized for `Option<_>`
+[`arcstr`](https://crates.io/crates/arcstr)           | 8 bytes  | ?     | ?        | ?              | ?       | ?      | ?
+[`compact_str`](https://crates.io/crates/compact_str) | 24 bytes | **Y** | 24 bytes | **Y**          | **Y**   | **Y** (miri, proptest, fuzz)  | Space optimized for `Option<_>`
 [`ecow`](https://crates.io/crates/ecow)               | 16 bytes | **Y** | 15 bytes | N              | **Y**   | **Y** (miri) | O(1) clone unless mutated, Space optimized for `Option<_>`
 [`flexstr`](https://crates.io/crates/flexstr)         | 24 bytes | **Y** | 22 bytes | **Y**          | N       | **Y** (miri) | O(1) clone
 [`hipstr`](https://crates.io/crates/hipstr)           | 24 bytes | ?     | 23 bytes | ?              | ?       | ?  | ?


### PR DESCRIPTION
As of v0.8 a `CompactString` can abstract over a `&'static str`, this PR updates the comparison table to reflect that.

Thanks again @epage for maintaining this!