### PR TITLE
feat: add borrowed constructor support for hipstr

### DIFF
--- a/benches/access.rs
+++ b/benches/access.rs
@@ -128,6 +128,15 @@ fn bench_access_static(c: &mut Criterion) {
             },
         );
         group.bench_with_input(
+            BenchmarkId::new("hipstr::HipStr::borrowed", len),
+            &len,
+            |b, _| {
+                let uut = hipstr::HipStr::borrowed(*fixture);
+                let uut = criterion::black_box(uut);
+                b.iter(|| uut.is_empty())
+            },
+        );
+        group.bench_with_input(
             BenchmarkId::new("KString::from_static", len),
             &len,
             |b, _| {

--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -126,6 +126,15 @@ fn bench_clone_static(c: &mut Criterion) {
             },
         );
         group.bench_with_input(
+            BenchmarkId::new("hipstr::HipStr::borrowed", len),
+            &len,
+            |b, _| {
+                let uut = hipstr::HipStr::borrowed(*fixture);
+                let uut = criterion::black_box(uut);
+                b.iter(|| uut.clone())
+            },
+        );
+        group.bench_with_input(
             BenchmarkId::new("KString::from_static", len),
             &len,
             |b, _| {

--- a/benches/new.rs
+++ b/benches/new.rs
@@ -105,7 +105,14 @@ fn bench_new_static(c: &mut Criterion) {
                 b.iter(|| flexstr::SharedStr::from_static(fixture))
             },
         );
-
+        group.bench_with_input(
+            BenchmarkId::new("hipstr::HipStr::borrowed", len),
+            &len,
+            |b, _| {
+                let fixture = criterion::black_box(*fixture);
+                b.iter(|| hipstr::HipStr::borrowed(fixture))
+            },
+        );
         group.bench_with_input(
             BenchmarkId::new("KString::from_static", len),
             &len,

--- a/benches/self_eq.rs
+++ b/benches/self_eq.rs
@@ -160,6 +160,17 @@ fn bench_self_eq_static(c: &mut Criterion) {
             },
         );
         group.bench_with_input(
+            BenchmarkId::new("hipstr::HipStr::borrowed", len),
+            &len,
+            |b, _| {
+                let uut = hipstr::HipStr::borrowed(*fixture);
+                let uut = criterion::black_box(uut);
+                let copy = uut.clone();
+                let copy = criterion::black_box(copy);
+                b.iter(|| uut == copy)
+            },
+        );
+        group.bench_with_input(
             BenchmarkId::new("KString::from_static", len),
             &len,
             |b, _| {


### PR DESCRIPTION
add missing benchmarks on hipstr's 'static constructor (actually any 'lifetime)