### PR TITLE
Add CompactString::const_new

### DIFF
--- a/benches/access.rs
+++ b/benches/access.rs
@@ -125,6 +125,15 @@ fn bench_access_static(c: &mut Criterion) {
             },
         );
         group.bench_with_input(
+            BenchmarkId::new("CompactString::const_new", len),
+            &len,
+            |b, _| {
+                let uut = compact_str::CompactString::const_new(*fixture);
+                let uut = std::hint::black_box(uut);
+                b.iter(|| uut.is_empty())
+            },
+        );
+        group.bench_with_input(
             BenchmarkId::new("flexstr::SharedStr::from_static", len),
             &len,
             |b, _| {

--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -123,6 +123,15 @@ fn bench_clone_static(c: &mut Criterion) {
             },
         );
         group.bench_with_input(
+            BenchmarkId::new("CompactString::const_new", len),
+            &len,
+            |b, _| {
+                let uut = compact_str::CompactString::const_new(*fixture);
+                let uut = std::hint::black_box(uut);
+                b.iter(|| uut.clone())
+            },
+        );
+        group.bench_with_input(
             BenchmarkId::new("flexstr::SharedStr::from_static", len),
             &len,
             |b, _| {

--- a/benches/new.rs
+++ b/benches/new.rs
@@ -104,6 +104,14 @@ fn bench_new_static(c: &mut Criterion) {
             },
         );
         group.bench_with_input(
+            BenchmarkId::new("CompactString::const_new", len),
+            &len,
+            |b, _| {
+                let fixture = std::hint::black_box(*fixture);
+                b.iter(|| compact_str::CompactString::const_new(fixture))
+            },
+        );
+        group.bench_with_input(
             BenchmarkId::new("flexstr::SharedStr::from_static", len),
             &len,
             |b, _| {

--- a/benches/self_eq.rs
+++ b/benches/self_eq.rs
@@ -155,6 +155,17 @@ fn bench_self_eq_static(c: &mut Criterion) {
             },
         );
         group.bench_with_input(
+            BenchmarkId::new("CompactString::const_new", len),
+            &len,
+            |b, _| {
+                let uut = compact_str::CompactString::const_new(*fixture);
+                let uut = std::hint::black_box(uut);
+                let copy = uut.clone();
+                let copy = std::hint::black_box(copy);
+                b.iter(|| uut == copy)
+            },
+        );
+        group.bench_with_input(
             BenchmarkId::new("flexstr::SharedStr::from_static", len),
             &len,
             |b, _| {


### PR DESCRIPTION
Hello!
`CompactString` can be created from `&'static str` using `CompactString::const_new`, so I added benchmarks.
ref: https://docs.rs/compact_str/0.9.0/compact_str/struct.CompactString.html#method.const_new