### PR TITLE
Allow clippy warnings

### DIFF
--- a/benches/access.rs
+++ b/benches/access.rs
@@ -1,7 +1,7 @@
 #![allow(
     clippy::clone_on_copy,
     clippy::useless_conversion,
-    clippy::clone_double_ref
+    clippy::explicit_auto_deref
 )]
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};

--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -1,7 +1,8 @@
 #![allow(
     clippy::clone_on_copy,
     clippy::useless_conversion,
-    clippy::clone_double_ref
+    clippy::explicit_auto_deref,
+    noop_method_call
 )]
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};

--- a/benches/new.rs
+++ b/benches/new.rs
@@ -1,8 +1,4 @@
-#![allow(
-    clippy::clone_on_copy,
-    clippy::useless_conversion,
-    clippy::clone_double_ref
-)]
+#![allow(clippy::clone_on_copy, clippy::useless_conversion)]
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 

--- a/benches/self_eq.rs
+++ b/benches/self_eq.rs
@@ -1,7 +1,8 @@
 #![allow(
     clippy::clone_on_copy,
     clippy::useless_conversion,
-    clippy::clone_double_ref
+    clippy::explicit_auto_deref,
+    noop_method_call
 )]
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};


### PR DESCRIPTION
Allow some lint rules by Clippy.

Current:

```
$ cargo clippy --workspace --all-features --all-targets -- -D warnings --allow deprecated
    Checking string-benchmarks-rs v0.1.0 (/Users/ryota2357/Projects/Rust/string-rosetta-rs)
error: lint `clippy::clone_double_ref` has been renamed to `suspicious_double_ref_op`
 --> benches/self_eq.rs:4:5
  |
4 |     clippy::clone_double_ref
  |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `suspicious_double_ref_op`
  |
  = note: `-D renamed-and-removed-lints` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(renamed_and_removed_lints)]`

error: lint `clippy::clone_double_ref` has been renamed to `suspicious_double_ref_op`
 --> benches/clone.rs:4:5
  |
4 |     clippy::clone_double_ref
  |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `suspicious_double_ref_op`
  |
  = note: `-D renamed-and-removed-lints` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(renamed_and_removed_lints)]`

error: lint `clippy::clone_double_ref` has been renamed to `suspicious_double_ref_op`
 --> benches/access.rs:4:5
  |
4 |     clippy::clone_double_ref
  |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `suspicious_double_ref_op`
  |
  = note: `-D renamed-and-removed-lints` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(renamed_and_removed_lints)]`

error: lint `clippy::clone_double_ref` has been renamed to `suspicious_double_ref_op`
 --> benches/new.rs:4:5
  |
4 |     clippy::clone_double_ref
  |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `suspicious_double_ref_op`
  |
  = note: `-D renamed-and-removed-lints` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(renamed_and_removed_lints)]`

error: deref which would be done by auto-deref
  --> benches/access.rs:77:50
   |
77 |             let uut = kstring::KString::from_ref(*fixture);
   |                                                  ^^^^^^^^ help: try: `fixture`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
   = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::explicit_auto_deref)]`

error: deref which would be done by auto-deref
  --> benches/clone.rs:77:50
   |
77 |             let uut = kstring::KString::from_ref(*fixture);
   |                                                  ^^^^^^^^ help: try: `fixture`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
   = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::explicit_auto_deref)]`

error: deref which would be done by auto-deref
   --> benches/access.rs:131:59
    |
131 |                 let uut = flexstr::SharedStr::from_static(*fixture);
    |                                                           ^^^^^^^^ help: try: `fixture`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

error: deref which would be done by auto-deref
   --> benches/access.rs:140:52
    |
140 |                 let uut = hipstr::HipStr::borrowed(*fixture);
    |                                                    ^^^^^^^^ help: try: `fixture`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

error: deref which would be done by auto-deref
   --> benches/access.rs:149:57
    |
149 |                 let uut = kstring::KString::from_static(*fixture);
    |                                                         ^^^^^^^^ help: try: `fixture`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

error: deref which would be done by auto-deref
   --> benches/clone.rs:129:59
    |
129 |                 let uut = flexstr::SharedStr::from_static(*fixture);
    |                                                           ^^^^^^^^ help: try: `fixture`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

error: deref which would be done by auto-deref
   --> benches/clone.rs:138:52
    |
138 |                 let uut = hipstr::HipStr::borrowed(*fixture);
    |                                                    ^^^^^^^^ help: try: `fixture`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

error: deref which would be done by auto-deref
   --> benches/clone.rs:147:57
    |
147 |                 let uut = kstring::KString::from_static(*fixture);
    |                                                         ^^^^^^^^ help: try: `fixture`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

error: deref which would be done by auto-deref
  --> benches/self_eq.rs:97:50
   |
97 |             let uut = kstring::KString::from_ref(*fixture);
   |                                                  ^^^^^^^^ help: try: `fixture`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
   = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::explicit_auto_deref)]`

error: call to `.clone()` on a reference in this situation does nothing
   --> benches/clone.rs:114:26
    |
114 |             b.iter(|| uut.clone())
    |                          ^^^^^^^^ help: remove this redundant call
    |
    = note: the type `str` does not implement `Clone`, so calling `clone` on `&str` copies the reference, which does not do anything and can be removed
    = note: `-D noop-method-call` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(noop_method_call)]`

error: deref which would be done by auto-deref
   --> benches/self_eq.rs:161:59
    |
161 |                 let uut = flexstr::SharedStr::from_static(*fixture);
    |                                                           ^^^^^^^^ help: try: `fixture`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

error: deref which would be done by auto-deref
   --> benches/self_eq.rs:172:52
    |
172 |                 let uut = hipstr::HipStr::borrowed(*fixture);
    |                                                    ^^^^^^^^ help: try: `fixture`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

error: deref which would be done by auto-deref
   --> benches/self_eq.rs:183:57
    |
183 |                 let uut = kstring::KString::from_static(*fixture);
    |                                                         ^^^^^^^^ help: try: `fixture`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

error: could not compile `string-benchmarks-rs` (bench "new") due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `string-benchmarks-rs` (bench "access") due to 5 previous errors
error: call to `.clone()` on a reference in this situation does nothing
   --> benches/self_eq.rs:142:27
    |
142 |             let copy = uut.clone();
    |                           ^^^^^^^^ help: remove this redundant call
    |
    = note: the type `str` does not implement `Clone`, so calling `clone` on `&str` copies the reference, which does not do anything and can be removed
    = note: `-D noop-method-call` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(noop_method_call)]`

error: could not compile `string-benchmarks-rs` (bench "clone") due to 6 previous errors
error: could not compile `string-benchmarks-rs` (bench "self_eq") due to 6 previous errors
